### PR TITLE
add support for CARRIAGECONTROL ConnectSpec

### DIFF
--- a/fortran/syntax/Main.sdf
+++ b/fortran/syntax/Main.sdf
@@ -2822,6 +2822,7 @@ context-free syntax
   'NEWUNIT'      '='  IntVariable                -> ConnectSpec   {cons("NEWUNIT")}
   'PAD'          '='  DefaultCharExpr            -> ConnectSpec   {cons("PAD")}
   'POSITION'     '='  DefaultCharExpr            -> ConnectSpec   {cons("POSITION")}
+  'CARRIAGECONTROL' '=' DefaultCharExpr          -> ConnectSpec   {cons("CARRIAGECONTROL")}
   'RECL'         '='  IntExpr                    -> ConnectSpec   {cons("RECL")}
   'ROUND'        '='  DefaultCharExpr            -> ConnectSpec   {cons("ROUND")}
   'SIGN'         '='  DefaultCharExpr            -> ConnectSpec   {cons("SIGN")}


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gfortran/Extended-I_002fO-specifiers.html


```
SUBROUTINE OpenCon()
    OPEN (UNIT = 26, FILE = FNAME, STATUS = 'OLD', CARRIAGECONTROL = 'FORTRAN')
    RETURN
END SUBROUTINE OpenCon
```